### PR TITLE
fix parsing of echo .desktop files during install process

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ fi
 echo "Installing rpgmaker-linux v$version"
 
 mainfd="$HOME/desktopapps/nwjs"
-localapplicationsfd="$HOME/.local/share/applications/"
+localapplicationsfd="$HOME/.local/share/applications"
 localbin="$HOME/.local/bin"
 
 arch=$(uname -m)
@@ -62,7 +62,7 @@ cp "$installpath/install.sh" "$mainfd"
 cp -r "$installpath/nwjs/" "$mainfd"
 
 # echo "Making a desktop file"
-echo "[Desktop Entry]
+echo -e "[Desktop Entry]
 Name=RPG Maker MV/MZ (cicpoffs mount)
 Exec=env gamef=\"%u\" $mainfd/nwjs/packagefiles/nwjsstart-cicpoffs.sh --chooselatestnwjs
 Type=Application
@@ -74,7 +74,7 @@ Terminal=true
 NoDisplay=true" > "$localapplicationsfd/nwjstest.desktop"
 chmod +x "$localapplicationsfd/nwjstest.desktop"
 
-echo "[Desktop Entry]
+echo -e "[Desktop Entry]
 Name=RPG Maker MV/MZ Options
 Exec=env gamef=\"%u\" $mainfd/nwjs/packagefiles/nwjsstart-cicpoffs.sh --gui
 Type=Application
@@ -83,7 +83,7 @@ StartupNotify=true
 MimeType=application/x-ms-dos-executable;application/x-wine-extension-msp;
 Icon=$mainfd/nwjs/packagefiles/nwjs128.png
 Terminal=true
-NoDisplay=true" > "$localapplicationsfd/nwjstoptions.desktop"
+NoDisplay=true" > "$localapplicationsfd/nwjsoptions.desktop"
 chmod +x "$localapplicationsfd/nwjsoptions.desktop"
 
 # Exec=bash -c "/home/pasha/desktopapps/nwjs/nwjs/packagefiles/nwjsstart-cicpoffs.sh --latestnwjs --gamepath '$(pwd)'";#

--- a/install.sh
+++ b/install.sh
@@ -59,7 +59,7 @@ createfd "$localbin"
 
 checkthebinaryarch "$installpath/nwjs/cicpoffs"
 cp "$installpath/install.sh" "$mainfd"
-cp -r "$installpath/nwjs/" "$mainfd"
+cp -r "$installpath/nwjs" "$mainfd"
 
 # echo "Making a desktop file"
 echo -e "[Desktop Entry]
@@ -89,6 +89,7 @@ chmod +x "$localapplicationsfd/nwjsoptions.desktop"
 # Exec=bash -c "/home/pasha/desktopapps/nwjs/nwjs/packagefiles/nwjsstart-cicpoffs.sh --latestnwjs --gamepath '$(pwd)'";#
 
 lnnew "$mainfd/nwjs/packagefiles/nwjsstart-cicpoffs.sh" "$localbin/rpgmaker-linux"
+chmod +x "$localbin/rpgmaker-linux"
 update-desktop-database -q ~/.local/share/applications
 
 echo "Installation Done"


### PR DESCRIPTION
Tried installing the tool, got this output:
<details><summary>Details</summary>
<p>

```
❯ wget -qO- "https://raw.githubusercontent.com/bakustarver/rpgmakermlinux-cicpoffs/main/installgithub.sh" | bash
--2024-05-15 00:43:58--  https://github.com/bakustarver/rpgmakermlinux-cicpoffs/releases/download/v1.0.6/rpgmakerlinux-x86_64-v1.0.6.tar.gz
Resolving github.com (github.com)... 20.205.243.166
Connecting to github.com (github.com)|20.205.243.166|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/766951109/ed7d5def-ec13-4017-a8ae-6c2a7c599668?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240514%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240514T174358Z&X-Amz-Expires=300&X-Amz-Signature=c8b3ee673658fc17a25d48c76c495ca82cd34838286517f4ec7bdbd119c492f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=766951109&response-content-disposition=attachment%3B%20filename%3Drpgmakerlinux-x86_64-v1.0.6.tar.gz&response-content-type=application%2Foctet-stream [following]
--2024-05-15 00:43:58--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/766951109/ed7d5def-ec13-4017-a8ae-6c2a7c599668?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=releaseassetproduction%2F20240514%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240514T174358Z&X-Amz-Expires=300&X-Amz-Signature=c8b3ee673658fc17a25d48c76c495ca82cd34838286517f4ec7bdbd119c492f9&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=766951109&response-content-disposition=attachment%3B%20filename%3Drpgmakerlinux-x86_64-v1.0.6.tar.gz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.111.133, 185.199.108.133, 185.199.109.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.111.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 164079454 (156M) [application/octet-stream]
Saving to: ‘/tmp/rpgmakerlinux-x86_64-v1.0.6.tar.gz’

rpgmakerlinux-x86_64-v1.0.6.tar.gz                                100%[============================================================================================================================================================>] 156.48M  5.72MB/s    in 27s     

2024-05-15 00:44:26 (5.74 MB/s) - ‘/tmp/rpgmakerlinux-x86_64-v1.0.6.tar.gz’ saved [164079454/164079454]

Installing rpgmaker-linux v1.0.6
Missing /home/fenglengshun/desktopapps/nwjs creating one
chmod: cannot access '/home/fenglengshun/.local/share/applications//nwjsoptions.desktop': No such file or directory
Installation Done
```

</p>
</details> 

Based on the last part, I checked the `install.sh`:

1. Change `localapplicationsfd="$HOME/.local/share/applications/"` to `localapplicationsfd="$HOME/.local/share/applications"` (prevents double slash during chmod)
2. Fix typo at line 86 (`nwjstoptions.desktop` instead of `nwjsoptions.desktop`) which creates wrong filename (hence chmod not detecting the file even after fixing double slash issue).
3. Add `chmod +x "$localbin/rpgmaker-linux"` so created file at localbin has executable permission.
4. I also reflexively changed `echo` to `echo -e` since there's use of escape sequence in the echo process - idk if that mattered in this case, but it seems to correctly create the .desktop file

Tested on my machine, seems to install correctly. That said, there seems to be other double slash issues with the script as even after it installed correctly I got:

```
❯ rpgmaker-linux             
Missing file /home/fenglengshun/desktopapps/nwjs/nwjs/nwjs/www//nw
/home/fenglengshun/desktopapps/nwjs/nwjs/nwjs/www//nw: cannot open `/home/fenglengshun/desktopapps/nwjs/nwjs/nwjs/www//nw' (No such file or directory)
Wrong architecture!! Use
$ rpgmaker-linux --fullupdate
to get correct version
```

I run zsh btw, if that matters.

<details><summary>System Info</summary>
<p>

```
❯ neofetch --off
fenglengshun@bbh-laptop 
----------------------- 
Host: HP Laptop 14s-fq2xxx 
OCI: Bazzite (Desktop Edition) x86_64 
OS: Fedora Linux 39.20240419.0 (Bazzite) x86_64 
Kernel: 6.7.12-202.fsync.fc39.x86_64 
Uptime: 2 days, 9 hours, 4 mins 
Packages: 2809 (rpm), 5 (steam), 1871 (nix), 79 (flatpak) 
Shell: bash 5.2.26 
Resolution: 1920x1080 
DE: Plasma 5.27.11 [KF5 5.115.0] [Qt 5.15.12] (wayland) 
WM: kwin_wayland_wr kwin_wayland 
WM Theme: WhiteSur-dark 
Theme: Monterey-dark [KDE], WhiteSur-Dark-solid [GTK2/3] 
Icons: WhiteSur-dark [KDE/Qt/GTK2/3] 
Terminal: konsole 
Terminal Font: MesloLGS NF 8 
CPU: AMD Ryzen 5 5625U (12) @ 4.3GHz 
GPU: AMD ATI Barcelo 
Memory: 7.63 GiB / 14.96 GiB (51%) 
```
</p>
</details> 

Sorry if there's any mistake btw, it's 1AM.