### PR TITLE
add changed and changed-special specific fixes

### DIFF
--- a/mkxp-z/Kawariki-patches/patches.rb
+++ b/mkxp-z/Kawariki-patches/patches.rb
@@ -164,6 +164,21 @@ module Preload
         .imported?(nil)
         .include?("======\nMoonpearl's Scene_Base\n-----")
         .flag!(:redefinitions_overwrite_class),
+        Patch.new("CHANGED: F12 Crash fix")
+            .if? {|script| script.name == "Super"}
+            .if? {|script| script.context[:rgss_version] == 2}
+            .include?("# A N T I L A G    V X")
+            .remove!,
+        Patch.new("CHANGED: Font fix")
+            .if? {|script| script.name == "Main"}
+            .if? {|script| script.context[:rgss_version] == 2}
+            .sub!('Font.default_name = ["Source Han Sans K Normal"', 'Font.default_name = ["Source Han Sans K"'),
+        Patch.new("Changed-special: Spriteset_Map fix")
+            .if? {|script| script.name == "Spriteset_Map"}
+            .if? {|script| script.context[:rgss_version] == 2}
+            .include?("def update_parallax")
+            .sub!('@parallax.ox = $game_map.calc_parallax_x(@parallax.bitmap)', "begin; @parallax.ox = $game_map.calc_parallax_x(@parallax.bitmap)")
+            .sub!('@parallax.oy = $game_map.calc_parallax_y(@parallax.bitmap)', "@parallax.oy = $game_map.calc_parallax_y(@parallax.bitmap); rescue; end"),
         # Generic Inline Patches
         Patch.new("Disable all font effects")
             .flag?(:no_font_effects) # KAWARIKI_MKXP_NO_FONT_EFFECTS


### PR DESCRIPTION
how to replicate the issues that these patches fix:
- **F12 Crash fix**: create a savefile, press f12 and then load the save you just made, the game will crash
- **Font fix**: simply start the game. the font is incorrect and can be proved by going in the language selection window and looking at how barely any character renders correctly, by just playing the game and looking at the text cutting off in message boxes, *or* by simply looking at the program's logs where something along the lines of "Failed to load primary font Source Han Sans K Normal" will be there
- **Spriteset_Map fix**: (on 10/31/2024 update of patreon special edition at least) go in any room with a parallax (the ones i've tested are map ID 055 and map ID 047, should work in every other map with a parallax though) and press W, the game will crash

few notes:
- i'm not sure if i implemented these correctly. if i was meant to put them somewhere else or i should've done it in a different way or anything like that, please tell me! 
- the "F12 Crash fix" patch **might** cause issues in other games that use antilag vx? though i doubt it due to games performing just fine even without it
- the "Spriteset_Map fix" patch **does** edit the script on every RPGVX game, though it should stop the same error from happening in other games anyway. the only thing it does is catching any error the parallax updating might cause so it shouldn't be a big deal